### PR TITLE
fix(prepare_dataset): import process_midi_attributesv2 lazily

### DIFF
--- a/scripts/prepare_dataset.py
+++ b/scripts/prepare_dataset.py
@@ -17,7 +17,11 @@ from platune.datasets.audio_example import AudioExample
 
 from platune.datasets.transforms import BasicPitchPytorch
 from platune.datasets.audio_descriptors import compute_all
-from platune.datasets.process_attributes import process_midi_attributes, process_midi_attributesv2, get_midi_notes
+from platune.datasets.process_attributes import process_midi_attributes, get_midi_notes
+try:
+    from platune.datasets.process_attributes import process_midi_attributesv2
+except ImportError:
+    process_midi_attributesv2 = None
 
 
 torch.set_grad_enabled(False)
@@ -323,6 +327,10 @@ def main(
                             if version == 'v1':
                                 attr_midi = process_midi_attributes(x=midi, instrument_val=cur_metadata["instrument"])
                             elif version == 'v2':
+                                if process_midi_attributesv2 is None:
+                                    raise NotImplementedError(
+                                        "process_midi_attributesv2 is not defined in platune.datasets.process_attributes"
+                                    )
                                 pitch, onset, offset, _ = get_midi_notes(midi)
                                 attr_midi = process_midi_attributesv2(pitch, onset, offset, instrument_val=cur_metadata["instrument"])
 


### PR DESCRIPTION
Closes #1.

## What

Make the import of `process_midi_attributesv2` in `scripts/prepare_dataset.py` lazy, and raise `NotImplementedError` in the `version == 'v2'` branch when the symbol is missing.

## Why

`scripts/prepare_dataset.py:20` currently imports `process_midi_attributesv2` from `platune.datasets.process_attributes`, but that function is not defined there. As a result every invocation — including just `prepare_dataset.py --help` and the default `--version v1` path — fails immediately with `ImportError` at module load time:

```
ImportError: cannot import name 'process_midi_attributesv2' from 'platune.datasets.process_attributes'
```

This means `prepare_dataset.py` is not runnable from a fresh clone today. See #1.

## Diff

- Split the import: `process_midi_attributes` and `get_midi_notes` are required, `process_midi_attributesv2` becomes optional via `try/except ImportError`.
- In the `version == 'v2'` branch, raise `NotImplementedError` if `process_midi_attributesv2 is None`, so the default `v1` path keeps working and `-v v2` fails loudly with a clear message instead of silently corrupting state.

## Verification

```bash
python -m venv .venv
.venv/bin/pip install -r requirements.txt && .venv/bin/pip install -e .
.venv/bin/python scripts/prepare_dataset.py --help    # now succeeds
```

Smoke-tested end-to-end on a single MP3 with `music2latent`, `solo_parser`, `--version v1`, basic-pitch + MIDI attributes — runs to completion and writes the LMDB.