### PR TITLE
fix(prepare_dataset): guard -inf loudness checks when feat is None

### DIFF
--- a/scripts/prepare_dataset.py
+++ b/scripts/prepare_dataset.py
@@ -287,11 +287,11 @@ def main(
                     # compute audio descriptors
                     feat = compute_all(audio_array) if len(descriptors_list) > 0 else None
 
-                    if 'integrated_loudness' in feat and np.any(feat['integrated_loudness'] == float("-inf")):
+                    if feat is not None and 'integrated_loudness' in feat and np.any(feat['integrated_loudness'] == float("-inf")):
                         skip_examples_inf_loud += 1
                         continue
 
-                    if 'loudness1s' in feat and np.any(feat['loudness1s'] == float("-inf")):
+                    if feat is not None and 'loudness1s' in feat and np.any(feat['loudness1s'] == float("-inf")):
                         skip_examples_inf_loud += 1
                         continue
                     


### PR DESCRIPTION
Closes #2.

## What

Guard the two `'<key>' in feat` checks with `feat is not None`.

## Why

A few lines earlier the script does

```python
feat = compute_all(audio_array) if len(descriptors_list) > 0 else None
```

so `feat` is `None` whenever the user passes no `-l / --descriptors_list` flags. The two guards below then crash on the first chunk:

```
if 'integrated_loudness' in feat and np.any(...): ...
TypeError: argument of type 'NoneType' is not iterable
```

This matters for any training config with `CONTINUOUS_KEYS = []` (e.g. the shipped `v1.gin`), where computing audio descriptors is wasted work — the natural invocation is to omit `-l` entirely. Without this fix, every such use of `prepare_dataset.py` aborts on the very first chunk after encoding.

## Diff

Two-line change: add `feat is not None and …` to both guards.

## Verification

Re-ran the full pipeline on a single MP3 with `-m music2latent --use_basic_pitch --midi_attributes` and **no** `-l` flags — preprocessing now completes and the LMDB is written.