### PR TITLE
fix(train): bind device explicitly on CPU-only machines

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -124,9 +124,11 @@ def main(
     # device = "cuda:" + str(gpu) if torch.cuda.is_available() and gpu >= 0 else "cpu"
     # if device.startswith("cuda"):
     #     accelerator = "cuda"
-    accelerator =  "cuda" if torch.cuda.is_available() and gpu >= 0 else None
+    accelerator = "cuda" if torch.cuda.is_available() and gpu >= 0 else "cpu"
     if accelerator == "cuda":
         device = gpu
+    else:
+        device = 1
     print(f'device - selected gpu: {accelerator}:{device}')
 
 


### PR DESCRIPTION
Closes #3.

## What

Set `accelerator='cpu', device=1` in the no-GPU branch so the Lightning Trainer is always constructed with a valid `(accelerator, devices)` pair.

## Why

`scripts/train.py:127-129` reads:

```python
accelerator = "cuda" if torch.cuda.is_available() and gpu >= 0 else None
if accelerator == "cuda":
    device = gpu
print(f'device - selected gpu: {accelerator}:{device}')
```

`device` is only assigned inside the `if accelerator == "cuda":` branch, so on any CPU-only machine the very next print raises:

```
UnboundLocalError: cannot access local variable 'device' where it is not associated with a value
```

This blocks training on macOS, CPU-only Linux, and Kaggle kernels with the GPU accelerator turned off.

## Diff

```diff
-    accelerator =  "cuda" if torch.cuda.is_available() and gpu >= 0 else None
+    accelerator = "cuda" if torch.cuda.is_available() and gpu >= 0 else "cpu"
     if accelerator == "cuda":
         device = gpu
+    else:
+        device = 1
     print(f'device - selected gpu: {accelerator}:{device}')
```

`pl.Trainer(accelerator='cpu', devices=1, …)` is the conventional way to ask Lightning for a single-CPU run; using `accelerator=None, devices=-1` (the previous fall-through) is ambiguous on macOS where Lightning's auto-selection can pick MPS and break on unsupported ops.

## Verification

Smoke-tested end-to-end on macOS (no CUDA): `train.py … --gpu -1 --max_steps 50` completes 50 training steps, runs validation, and writes both `last.ckpt` and `best.ckpt`.