### PR TITLE
fix(v1.gin): set LATENT_DIM=64 to match music2latent.encode()

### DIFF
--- a/platune/configs/v1.gin
+++ b/platune/configs/v1.gin
@@ -10,7 +10,7 @@ from platune import model
 BATCH = 32
 N_WORKERS = 0
 
-LATENT_DIM = 32
+LATENT_DIM = 64  # music2latent.encode() returns 64-channel latents
 
 SEQ_LENGTH = 64
 


### PR DESCRIPTION
Closes #4.

> ⚠️ **Maintainer confirmation requested.** This PR assumes the README's quick-start (`-m music2latent`) is the intended codec for `v1.gin`. If `v1.gin` was actually tuned for a different (32-channel) codec, the right fix is the other direction — please advise and I'll close this in favor of a docs change.

## What

Change `LATENT_DIM` in `platune/configs/v1.gin` from `32` to `64`, with an inline comment explaining why.

## Why

`music2latent.EncoderDecoder.encode()` returns latents shaped `(B, 64, T)`:

```python
import librosa
from music2latent import EncoderDecoder
ed = EncoderDecoder(device='cpu')
x = librosa.load('any.wav', sr=44100, mono=True, duration=3)[0][:131072]
print(ed.encode(x).shape)
# torch.Size([1, 64, 31])
```

`prepare_dataset.py` writes those `(64, T)` tensors to LMDB. At training time, `transformerv2.Denoiser`'s first `nn.Linear(n_channels=LATENT_DIM, embed_dim)` expects 32-channel input but receives 64, so training cannot start with the codec the README installs.

## Diff

```diff
-LATENT_DIM = 32
+LATENT_DIM = 64  # music2latent.encode() returns 64-channel latents
```

## Verification

Smoke-tested end-to-end on a single MP3 → music2latent → LMDB → training (50 steps, validation, checkpointing) on CPU. `LATENT_DIM=64` matches the stored latent shape and the Lightning run completes; `LATENT_DIM=32` errors at the first forward pass.

## Alternative directions (if this PR is wrong)

If `v1.gin` was tuned for a 32-channel codec (a TorchScript codec that's not music2latent), then:
- the README's quick-start example should *not* use `-m music2latent`, and
- it would be helpful to ship the 32-channel codec or document where it lives.

Either way, the current state — `v1.gin` + the README's recommended codec — does not train. Happy to rework this PR as a docs change instead.